### PR TITLE
Fixed test_longest_field_in_line and autorun in test suite.

### DIFF
--- a/exercise03/test_exercise03.py
+++ b/exercise03/test_exercise03.py
@@ -38,9 +38,9 @@ class Test_exercise03(unittest.TestCase):
         self.assertEqual(nw, 11)
 
     def test_longest_field_in_line(self):
-        line_2 = get_line(self.fname, 2)
-        longest = longest_field_in_line(line_2)
+        line_0 = get_line(self.fname, 0)
+        longest = longest_field_in_line(line_0)
         self.assertEqual(longest, 'airport_id')
 
-    if __name__ == '__main__':
-        unittest.main()
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
test_longest_field_in_line was checking line 2 to make sure that the longest field was "airport_id", the longest field in line 0.  The actual longest field in line 2 is "Papua New Guinea".  I changed the test to test line 0.

Also, the indentation on the "if **name** == '**main**':" section was incorrect, so "python test_exercise03.py" would not actually run the tests.
