### PR TITLE
Solution for longest_field_in_line (and fields_in_line).

### DIFF
--- a/exercise03/exercise03.py
+++ b/exercise03/exercise03.py
@@ -58,6 +58,7 @@ def fields_in_line(line, delim=","):
     """
 
     fields = line.strip().split(delim)
+    return fields
 
 def n_fields_in_line(line):
     """
@@ -75,15 +76,16 @@ def n_fields_in_line(line):
     """
     pass
 
-def longest_field_in_line(line):
+def longest_field_in_line(line, delim=","):
     """
     Find the longest field in a line
 
     Arguments
     ---------
-
     line: str
          A string with delmited fields
+    delim: str
+           A single character used to delimit the fields
 
     Returns
     -------
@@ -91,4 +93,11 @@ def longest_field_in_line(line):
            The longest field in the delimted line
 
     """
-    pass
+    fields = fields_in_line(line, delim)
+    maxlen = 0
+    maxlenfield = ""
+    for field in fields:
+        if(len(field) > maxlen):
+            maxlen = len(field)
+            maxlenfield = field
+    return maxlenfield


### PR DESCRIPTION
I also added a delimiter argument to longest_field_in_line for compatibility with non-comma-delimited files.

Compare to https://github.com/sjsrey/gis321f16collaboratory/pull/4/commits/037b8d39b6c752e41914e4941680b4bea2ed3a0f - I think this version is a bit more readable.

(On a procedural note, is this a suitable way to suggest an alternate approach to part of someone else's pull request?  It seems like it might result in an awkward merge...)
